### PR TITLE
feat: update git to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 # Copyright (c) 2023 Lite XL Contributors
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,8 +26,12 @@ ADD libdecor-0-dev_0.1.0-3build1_amd64.deb libdecor-0-0_0.1.0-3build1_amd64.deb 
 # install deps
 RUN apt-get update && apt-get upgrade && \
 	apt-get install -y sudo ccache curl wget python3.7 python3-pip build-essential \
-		zip unzip git cmake wayland-protocols libsdl2-dev && \
+		zip unzip git cmake wayland-protocols libsdl2-dev software-properties-common && \
 	python3.7 -m pip install meson ninja
+
+# update git
+RUN sudo add-apt-repository -y ppa:git-core/ppa && \
+	sudo apt-get update -y && sudo apt-get --with-new-pkgs upgrade -y git
 
 # install libdecor
 RUN dpkg --force-all -i libdecor-0-dev_0.1.0-3build1_amd64.deb libdecor-0-0_0.1.0-3build1_amd64.deb


### PR DESCRIPTION
actions/checkout will require a newer version of Git to checkout submodules. Although we don't need it, there's no harm to upgrade git because we can now utilize the build box for native plugins.